### PR TITLE
Comment out last day data seeding during migration

### DIFF
--- a/CyberGameTime.API/Program.cs
+++ b/CyberGameTime.API/Program.cs
@@ -66,7 +66,7 @@ using (var scope = app.Services.CreateScope())
 
         // Generar y aplicar todas las migraciones en tiempo de ejecuci�n
         await GenerateAndApplyMigrations(context);
-        await DataSeeder.SeedLastDayAsync(context);
+        //await DataSeeder.SeedLastDayAsync(context);
         Console.WriteLine("Migraciones aplicadas exitosamente.");
     }
     catch (Exception ex)


### PR DESCRIPTION
This change disables the execution of `DataSeeder.SeedLastDayAsync(context)` during the database initialization process. This may help prevent potential issues during migration or allow for manual seeding at a later time.